### PR TITLE
Assign distinct API key inputs per chatbot page

### DIFF
--- a/pages/Sarcasm_Demo.py
+++ b/pages/Sarcasm_Demo.py
@@ -20,7 +20,7 @@ conversation_id = st.session_state[f"{PAGE_ID}_conversation_id"]
 
 # 侧边栏配置
 with st.sidebar:
-    api_key = st.text_input("Dify API Key", key="chatbot_api_key", type="password")
+    api_key = st.text_input("Dify API Key", key="sarcasm_dify_api_key", type="password")
     if st.button("Reset Conversation"):
         st.session_state[f"{PAGE_ID}_messages"] = [{"role": "assistant", "content": "你好! 你知道的我不好惹?"}]
         st.session_state[f"{PAGE_ID}_conversation_id"] = None

--- a/pages/gamechat_Demo.py
+++ b/pages/gamechat_Demo.py
@@ -3,7 +3,7 @@ import streamlit as st
 
 
 with st.sidebar:
-    openai_api_key = st.text_input("OpenAI API Key", key="chatbot_api_key", type="password")
+    openai_api_key = st.text_input("OpenAI API Key", key="gamechat_openai_api_key", type="password")
 
 
 st.title("💬 game Chatbot")


### PR DESCRIPTION
## Summary
- give the Sarcasm chatbot its own `sarcasm_dify_api_key` sidebar input key
- assign the game chatbot a unique `gamechat_openai_api_key` sidebar input key to avoid cross-page leakage

## Testing
- not run (manual verification required in a live Streamlit session)

------
https://chatgpt.com/codex/tasks/task_e_68cd17729d348320bad1f53304812f8a